### PR TITLE
Add evidence_tier and synmicdb_score fields to FrameEffect

### DIFF
--- a/packages/ghostframe/src/ghostframe/cli/main.py
+++ b/packages/ghostframe/src/ghostframe/cli/main.py
@@ -14,5 +14,9 @@ def cli() -> None:
 
 @cli.command()
 def analyze() -> None:
-    """Run the GhostFrame analysis pipeline."""
+    """Run the GhostFrame analysis pipeline.
+
+    Output table columns: variant_id, frame, old_class, new_class,
+    ref_aa, alt_aa, evidence_tier.
+    """
     raise NotImplementedError("Pipeline analysis not yet implemented")

--- a/packages/ghostframe/src/ghostframe/models.py
+++ b/packages/ghostframe/src/ghostframe/models.py
@@ -73,6 +73,8 @@ class FrameEffect:
     new_class: str  # reclassified (e.g. "Missense")
     ref_aa: str
     alt_aa: str
+    evidence_tier: int = 1  # 1=scan-only, 2=OpenProt-confirmed, 3=SynMICdb-scored
+    synmicdb_score: float | None = None
 
 
 @dataclass

--- a/packages/ghostframe/src/ghostframe/reports/export.py
+++ b/packages/ghostframe/src/ghostframe/reports/export.py
@@ -25,5 +25,10 @@ def to_tsv(results: object, path: Path) -> None:
     Args:
         results: Analysis results object.
         path: Output file path.
+
+    TSV columns (per peptide candidate):
+        variant_id, frame, effect_type, peptide_seq, allele, affinity_nm,
+        percentile_rank, domain_accession, domain_name, evidence_tier,
+        synmicdb_score, score
     """
     raise NotImplementedError("TSV export not yet implemented")


### PR DESCRIPTION
## Summary

- Adds `evidence_tier: int = 1` and `synmicdb_score: float | None = None` to `FrameEffect` in `models.py`
- Documents expected TSV columns in `reports/export.py`
- Documents expected CLI output columns in `cli/main.py`

## Evidence tier definitions

| Tier | Meaning |
|---|---|
| 1 | Scan-only — ATG→stop discovery in the sequence window (default) |
| 2 | OpenProt-confirmed — coordinates match a known AltORF |
| 3 | SynMICdb-scored — variant has recurrence/score data |

## Why

Prerequisite for #12 (evidence linking) and #15 (frontend evidence badges). Without these fields, all scanned ORFs look equally valid and the evidence module has nowhere to write its results.

Closes #22