### PR TITLE
Implement sliding_kmers peptide generator

### DIFF
--- a/packages/ghostframe/src/ghostframe/peptides/generator.py
+++ b/packages/ghostframe/src/ghostframe/peptides/generator.py
@@ -12,16 +12,30 @@ from ghostframe.models import Peptide
 def sliding_kmers(
     protein: str,
     mut_pos: int,
-    k_range: tuple[int, int] = (8, 11),
+    k_min: int = 8,
+    k_max: int = 11,
 ) -> list[Peptide]:
-    """Generate all k-mer peptides spanning a mutant position.
+    """Generate k-mer peptides that span the mutant position.
 
     Args:
-        protein: Full protein sequence.
-        mut_pos: 0-based position of the mutation in the protein.
-        k_range: Tuple of (min_k, max_k) for peptide lengths.
+        protein: Full protein sequence (single-letter AA codes).
+        mut_pos: 0-based position of the mutated amino acid.
+        k_min: Minimum peptide length (inclusive).
+        k_max: Maximum peptide length (inclusive).
 
     Returns:
-        List of Peptide objects spanning the mutant position.
+        All k-mers of lengths k_min..k_max that contain mut_pos,
+        skipping any window with stop ('*') or unknown ('X') characters.
     """
-    raise NotImplementedError("Peptide generation not yet implemented")
+    results: list[Peptide] = []
+    for k in range(k_min, k_max + 1):
+        # A window of size k starting at `start` contains mut_pos iff:
+        #   start <= mut_pos < start + k  →  start in [mut_pos-k+1, mut_pos]
+        start_lo = max(0, mut_pos - k + 1)
+        start_hi = min(len(protein) - k, mut_pos)
+        for start in range(start_lo, start_hi + 1):
+            window = protein[start : start + k]
+            if "*" in window or "X" in window:
+                continue
+            results.append(Peptide(sequence=window, start=start, k=k))
+    return results

--- a/tests/peptides/test_generator.py
+++ b/tests/peptides/test_generator.py
@@ -1,11 +1,69 @@
-"""Tests for peptide kmer generation — stubbed/skipped until implemented."""
+"""Tests for peptide kmer generation."""
 
-import pytest
+from ghostframe.models import Peptide
+from ghostframe.peptides.generator import sliding_kmers
 
 
-@pytest.mark.skip(reason="peptides.generator not yet implemented")
 class TestSlidingKmers:
-    def test_basic_kmer_generation(self) -> None:
+    def test_windows_span_mut_pos(self) -> None:
+        protein = "ACDEFGHIKLMNPQRSTVWY"  # 20 AA
+        mut_pos = 10
+        peptides = sliding_kmers(protein, mut_pos)
+        for p in peptides:
+            assert p.start <= mut_pos < p.start + p.k
 
-        # Will be tested once implemented
-        assert True
+    def test_all_k_lengths(self) -> None:
+        protein = "ACDEFGHIKLMNPQRSTVWY"  # 20 AA
+        peptides = sliding_kmers(protein, mut_pos=10)
+        lengths = {p.k for p in peptides}
+        assert lengths == {8, 9, 10, 11}
+
+    def test_count_mid_protein(self) -> None:
+        # 20 AA, mut_pos=10, k=8: start ranges from max(0,3)=3 to min(12,10)=10 → 8 windows
+        protein = "ACDEFGHIKLMNPQRSTVWY"
+        peptides = sliding_kmers(protein, mut_pos=10, k_min=8, k_max=8)
+        assert len(peptides) == 8
+
+    def test_mut_pos_at_start(self) -> None:
+        protein = "ACDEFGHIKLMNPQRSTVWY"
+        peptides = sliding_kmers(protein, mut_pos=0, k_min=8, k_max=8)
+        # Only start=0 is valid
+        assert len(peptides) == 1
+        assert peptides[0].start == 0
+
+    def test_mut_pos_at_end(self) -> None:
+        protein = "ACDEFGHIKLMNPQRSTVWY"  # len=20, last pos=19
+        peptides = sliding_kmers(protein, mut_pos=19, k_min=8, k_max=8)
+        # Only start=12 is valid (12 + 8 = 20)
+        assert len(peptides) == 1
+        assert peptides[0].start == 12
+
+    def test_skip_stop_codon(self) -> None:
+        # Place '*' inside the mutation window
+        protein = "ACDEFGHIK*MNPQRSTVWY"  # '*' at pos 9
+        peptides = sliding_kmers(protein, mut_pos=9, k_min=8, k_max=8)
+        assert all("*" not in p.sequence for p in peptides)
+
+    def test_skip_unknown_aa(self) -> None:
+        protein = "ACDEFGHIKXMNPQRSTVWY"  # 'X' at pos 9
+        peptides = sliding_kmers(protein, mut_pos=9, k_min=8, k_max=8)
+        assert all("X" not in p.sequence for p in peptides)
+
+    def test_protein_shorter_than_k_min(self) -> None:
+        protein = "ACDE"  # len=4, k_min=8
+        peptides = sliding_kmers(protein, mut_pos=2)
+        assert peptides == []
+
+    def test_peptide_fields(self) -> None:
+        protein = "ACDEFGHIKLMNPQRSTVWY"
+        peptides = sliding_kmers(protein, mut_pos=5, k_min=8, k_max=8)
+        for p in peptides:
+            assert isinstance(p, Peptide)
+            assert len(p.sequence) == p.k == 8
+            assert p.sequence == protein[p.start : p.start + p.k]
+
+    def test_custom_k_range(self) -> None:
+        protein = "ACDEFGHIKLMNPQRSTVWY"
+        peptides = sliding_kmers(protein, mut_pos=10, k_min=9, k_max=9)
+        assert all(p.k == 9 for p in peptides)
+        assert all(len(p.sequence) == 9 for p in peptides)


### PR DESCRIPTION
Closes #10

## Summary

- Implements `sliding_kmers(protein, mut_pos, k_min=8, k_max=11) -> list[Peptide]`
- Only generates windows that **span the mutant position** — peptides far from the mutation are wild-type identical and irrelevant for neoantigen prediction
- Skips windows containing stop characters (`*`) or unknown AAs (`X`)
- 10 tests covering mid-protein, boundary positions, filtering, and field correctness

## Signature note

The issue spec listed `sliding_kmers(protein, k_min, k_max)` with no `mut_pos`. We kept `mut_pos` from the stub (biologically correct — only mutation-spanning windows matter for MHC prediction) and adopted the cleaner `k_min`/`k_max` kwargs instead of the tuple.

## Test plan

- [x] `uv run pytest tests/peptides/ -v` — 10/10 pass
- [x] 20 AA protein, mut_pos=10, k=8 → 8 windows (matches expected count)