### PR TITLE
Implement candidate ranking and scoring (closes #26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ When planning or implementing any module, ask: *is there a standard library or w
 | `mhc/` | Implemented | MHC binding prediction (MHCflurry) |
 | `domain/` | Implemented | Pfam domain annotation via EMBL-EBI HMMER JDispatcher |
 | `evidence/` | Implemented | OpenProt, SynMICdb, ClinVar linking |
-| `reports/` | Stubbed | Output generation |
+| `ranking/` | Implemented | Candidate scoring (scorer.py) and ranking (ranker.py + TSV export) |
+| `reports/` | Partial | TSV export via ranking.ranker; JSON stubbed |
 | `pipeline/` | Stubbed | Fast/deep lane orchestration |
 | `cli/` | Partial | Click CLI entry points |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ print('SynMICdb:', synmicdb.lookup(v))
 print('ClinVar:', clinvar.lookup(v))
 "
 
+# Score and rank neoantigen candidates (ranking module)
+uv run --package ghostframe python -c "
+from ghostframe.models import BindingPrediction, DomainHit, EvidenceLookupResult, FrameEffect, ORF, Peptide, ScoredCandidate
+from ghostframe.ranking import scorer, ranker
+
+orf = ORF(frame=1, pos=1, length=30, dna='ATG' * 10)
+effect = FrameEffect(orf=orf, old_class='Silent', new_class='Missense', ref_aa='A', alt_aa='V')
+binding = BindingPrediction(peptide=Peptide(sequence='GILGFVFTL', start=0, k=9), allele='HLA-A*02:01', affinity=120.0, rank=1.5)
+domain_hits = [DomainHit(accession='PF00071', name='Ras', start=5, end=39, score=42.0)]
+evidence = EvidenceLookupResult(tier=3)
+
+s = scorer.score(effect, binding, domain_hits, evidence)
+candidates = ranker.rank([ScoredCandidate(effect=effect, binding=binding, domain_hits=domain_hits, evidence=evidence, score=s)])
+print(f'Top candidate score: {candidates[0].score:.3f}')
+"
+
 # Run tests
 uv run pytest
 
@@ -69,7 +85,8 @@ ghostframe/
         mhc/              # MHC binding prediction (implemented)
         domain/           # Pfam domain annotation via EMBL-EBI HMMER (implemented)
         evidence/         # External evidence linking (implemented)
-        reports/          # Output generation (stubbed)
+        ranking/          # Candidate scoring and ranking (implemented)
+        reports/          # Output generation (TSV implemented)
         pipeline/         # Orchestration (stubbed)
         cli/              # CLI entry points
     ghostframe-api/       # FastAPI server
@@ -84,7 +101,7 @@ ghostframe/
 GhostFrame uses a two-lane pipeline:
 
 - **Fast Lane**: MAF intake -> filter Silent variants -> fetch reference sequence -> 6-frame ORF scan -> reclassify -> summary
-- **Deep Lane**: Generate mutant peptides -> MHC binding prediction -> external evidence linking -> report
+- **Deep Lane**: Generate mutant peptides -> MHC binding prediction -> domain annotation -> external evidence linking -> candidate scoring/ranking -> report
 
 See [docs/architecture.md](docs/architecture.md) for details.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,9 +30,9 @@ The CLI (`ghostframe analyze`) serves as the power-user path. The FastAPI server
 | `mhc/` | MHC binding prediction | Deep | Implemented |
 | `domain/` | HMMER/Pfam domain annotation via EMBL-EBI JDispatcher API | Deep | Implemented |
 | `evidence/` | OpenProt, SynMICdb, ClinVar linking | Deep | Implemented |
-| `ranking/` | Candidate scoring and ranking | Deep | Planned |
+| `ranking/` | Candidate scoring and ranking | Deep | Implemented |
 | `explain/` | LLM narrative explanation + MCP server | Deep | Planned |
-| `reports/` | Export (JSON, TSV) | Both | Stubbed |
+| `reports/` | Export (JSON, TSV) | Both | Partial (TSV implemented) |
 | `pipeline/` | Fast/deep lane orchestration | Both | Stubbed |
 | `cli/` | Click CLI entry points | N/A | Partial |
 

--- a/packages/ghostframe/src/ghostframe/models.py
+++ b/packages/ghostframe/src/ghostframe/models.py
@@ -194,6 +194,17 @@ class DomainHit:
 
 
 @dataclass
+class ScoredCandidate:
+    """A reclassified variant candidate with an aggregate priority score."""
+
+    effect: FrameEffect
+    binding: BindingPrediction | None
+    domain_hits: list[DomainHit]
+    evidence: EvidenceLookupResult | None
+    score: float
+
+
+@dataclass
 class FastLaneResult:
     """Result of the fast lane pipeline."""
 
@@ -210,4 +221,5 @@ class DeepLaneResult:
     binding_predictions: list[BindingPrediction]
     evidence: EvidenceLookupResult | None
     domain_hits: list[DomainHit] = field(default_factory=lambda: [])
+    ranked_candidates: list[ScoredCandidate] = field(default_factory=lambda: [])
     narrative: str | None = None

--- a/packages/ghostframe/src/ghostframe/ranking/__init__.py
+++ b/packages/ghostframe/src/ghostframe/ranking/__init__.py
@@ -1,0 +1,11 @@
+"""Candidate ranking and scoring for neoantigen prioritization.
+
+Combines MHC binding percentile rank, external evidence tier, and Pfam domain
+presence into a single score in [0, 1] per reclassified variant. Higher scores
+indicate higher-priority neoantigen candidates.
+
+Pipeline position: mhc.predict() + domain.scan() + evidence.lookup()
+    → ranking.scorer.score()
+    → ranking.ranker.rank()
+    → explain.narrator.explain()
+"""

--- a/packages/ghostframe/src/ghostframe/ranking/ranker.py
+++ b/packages/ghostframe/src/ghostframe/ranking/ranker.py
@@ -1,0 +1,94 @@
+"""Candidate ranking for neoantigen prioritization.
+
+Sorts pre-scored candidates by descending score and provides TSV export.
+"""
+
+import io
+from pathlib import Path
+
+from ghostframe.models import ScoredCandidate
+
+
+def rank(candidates: list[ScoredCandidate]) -> list[ScoredCandidate]:
+    """Sort candidates by descending priority score.
+
+    Args:
+        candidates: Pre-scored candidates (from scorer.score()).
+
+    Returns:
+        New list sorted descending by score. The input list is not modified.
+    """
+    return sorted(candidates, key=lambda c: c.score, reverse=True)
+
+
+TSV_HEADER = (
+    "variant_id\tframe\teffect_type\tpeptide_seq\tallele\t"
+    "affinity_nm\tpercentile_rank\tdomain_accession\tdomain_name\t"
+    "evidence_tier\tsynmicdb_score\tscore"
+)
+
+
+def to_tsv(candidates: list[ScoredCandidate], path: Path) -> None:
+    """Export ranked candidates as a TSV file.
+
+    Args:
+        candidates: Ranked candidates (pass through rank() first for sorted output).
+        path: Output file path.
+
+    TSV columns:
+        variant_id       — "<frame>:<pos>" from the ORF
+        frame            — reading frame (1-6)
+        effect_type      — reclassified effect (e.g. "Missense")
+        peptide_seq      — peptide sequence from the best binding prediction
+        allele           — HLA allele from the best binding prediction
+        affinity_nm      — IC50 nM (lower = stronger binder)
+        percentile_rank  — MHCflurry presentation percentile (0-100)
+        domain_accession — Pfam accession of first domain hit, or ""
+        domain_name      — Pfam name of first domain hit, or ""
+        evidence_tier    — 1 (scan-only), 2 (OpenProt), or 3 (SynMICdb)
+        synmicdb_score   — SynMICdb score if tier 3, else ""
+        score            — aggregate priority score in [0, 1]
+    """
+    buf = io.StringIO()
+    buf.write(TSV_HEADER + "\n")
+    for c in candidates:
+        orf = c.effect.orf
+        variant_id = f"{orf.frame}:{orf.pos}"
+        frame = str(orf.frame)
+        effect_type = c.effect.new_class
+
+        peptide_seq = c.binding.peptide.sequence if c.binding is not None else ""
+        allele = c.binding.allele if c.binding is not None else ""
+        affinity_nm = str(c.binding.affinity) if c.binding is not None else ""
+        percentile_rank = str(c.binding.rank) if c.binding is not None else ""
+
+        first_domain = c.domain_hits[0] if c.domain_hits else None
+        domain_accession = first_domain.accession if first_domain is not None else ""
+        domain_name = first_domain.name if first_domain is not None else ""
+
+        tier = c.evidence.tier if c.evidence is not None else 1
+        synmicdb_score = ""
+        if c.evidence is not None and c.evidence.synmicdb is not None:
+            raw = c.evidence.synmicdb.score
+            synmicdb_score = str(raw) if raw is not None else ""
+
+        buf.write(
+            "\t".join(
+                [
+                    variant_id,
+                    frame,
+                    effect_type,
+                    peptide_seq,
+                    allele,
+                    affinity_nm,
+                    percentile_rank,
+                    domain_accession,
+                    domain_name,
+                    str(tier),
+                    synmicdb_score,
+                    str(c.score),
+                ]
+            )
+            + "\n"
+        )
+    path.write_text(buf.getvalue(), encoding="utf-8")

--- a/packages/ghostframe/src/ghostframe/ranking/scorer.py
+++ b/packages/ghostframe/src/ghostframe/ranking/scorer.py
@@ -1,0 +1,53 @@
+"""Candidate scoring for neoantigen prioritization.
+
+Combines three signals into a single priority score in [0, 1]:
+  - MHC binding percentile rank (lower rank = stronger predicted binder)
+  - External evidence tier (OpenProt / SynMICdb confirmation)
+  - Pfam domain presence (known functional domain in the ORF)
+
+Weights are module-level constants and can be tuned without changing the formula.
+"""
+
+from ghostframe.models import (
+    BindingPrediction,
+    DomainHit,
+    EvidenceLookupResult,
+    FrameEffect,
+)
+
+# Scoring weights — must sum to 1.0
+_W_MHC: float = 0.5
+_W_EVIDENCE: float = 0.3
+_W_DOMAIN: float = 0.2
+
+
+def score(
+    effect: FrameEffect,
+    binding: BindingPrediction | None,
+    domain_hits: list[DomainHit],
+    evidence: EvidenceLookupResult | None,
+) -> float:
+    """Score a reclassified variant candidate.
+
+    Args:
+        effect: The FrameEffect describing the reclassified variant.
+        binding: Best MHC binding prediction for peptides from this ORF,
+            or None if no prediction was made.
+        domain_hits: Pfam domain hits in the translated ORF (may be empty).
+        evidence: Aggregated external evidence, or None if not looked up.
+
+    Returns:
+        Float in [0, 1]; higher = higher priority neoantigen candidate.
+
+        Score components:
+          - MHC:      0.5 * (1 - percentile_rank / 100)
+                      → 0.5 when rank=0 (best binder); 0.0 when rank=100 or no binding
+          - Evidence: 0.3 * (tier - 1) / 2
+                      → 0.0 at tier 1 (scan-only); 0.3 at tier 3 (SynMICdb-scored)
+          - Domain:   0.2 if any domain_hits, else 0.0
+    """
+    mhc_term = _W_MHC * (1.0 - binding.rank / 100.0) if binding is not None else 0.0
+    tier = evidence.tier if evidence is not None else 1
+    evidence_term = _W_EVIDENCE * (tier - 1) / 2.0
+    domain_term = _W_DOMAIN if domain_hits else 0.0
+    return mhc_term + evidence_term + domain_term

--- a/packages/ghostframe/src/ghostframe/reports/export.py
+++ b/packages/ghostframe/src/ghostframe/reports/export.py
@@ -3,10 +3,13 @@
 Serializes analysis results into structured output files for
 downstream consumption or visualization.
 
-Pipeline position: reclassify + mhc + evidence → [reports.export] → user
+Pipeline position: reclassify + mhc + evidence → ranking → [reports.export] → user
 """
 
 from pathlib import Path
+
+from ghostframe.models import ScoredCandidate
+from ghostframe.ranking import ranker
 
 
 def to_json(results: object, path: Path) -> None:
@@ -19,11 +22,11 @@ def to_json(results: object, path: Path) -> None:
     raise NotImplementedError("JSON export not yet implemented")
 
 
-def to_tsv(results: object, path: Path) -> None:
-    """Export analysis results as TSV.
+def to_tsv(candidates: list[ScoredCandidate], path: Path) -> None:
+    """Export ranked candidates as a TSV file.
 
     Args:
-        results: Analysis results object.
+        candidates: Ranked ScoredCandidate list (from ranking.ranker.rank()).
         path: Output file path.
 
     TSV columns (per peptide candidate):
@@ -31,4 +34,4 @@ def to_tsv(results: object, path: Path) -> None:
         percentile_rank, domain_accession, domain_name, evidence_tier,
         synmicdb_score, score
     """
-    raise NotImplementedError("TSV export not yet implemented")
+    ranker.to_tsv(candidates, path)

--- a/tests/ranking/test_ranker.py
+++ b/tests/ranking/test_ranker.py
@@ -1,0 +1,125 @@
+"""Unit tests for ranking.ranker."""
+
+from pathlib import Path
+
+from ghostframe.models import (
+    ORF,
+    BindingPrediction,
+    DomainHit,
+    EvidenceLookupResult,
+    FrameEffect,
+    Peptide,
+    ScoredCandidate,
+)
+from ghostframe.ranking import ranker
+
+# --- Helpers ---
+
+
+def _make_candidate(score: float) -> ScoredCandidate:
+    orf = ORF(frame=1, pos=1, length=30, dna="ATG" * 10)
+    effect = FrameEffect(orf=orf, old_class="Silent", new_class="Missense", ref_aa="A", alt_aa="V")
+    binding = BindingPrediction(
+        peptide=Peptide(sequence="GILGFVFTL", start=0, k=9),
+        allele="HLA-A*02:01",
+        affinity=100.0,
+        rank=5.0,
+    )
+    return ScoredCandidate(
+        effect=effect,
+        binding=binding,
+        domain_hits=[DomainHit(accession="PF00071", name="Ras", start=5, end=39, score=42.0)],
+        evidence=EvidenceLookupResult(tier=2),
+        score=score,
+    )
+
+
+# --- Tests ---
+
+
+def test_rank_descending_order() -> None:
+    candidates = [_make_candidate(0.3), _make_candidate(0.9), _make_candidate(0.6)]
+    result = ranker.rank(candidates)
+    scores = [c.score for c in result]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_rank_returns_new_list() -> None:
+    candidates = [_make_candidate(0.5), _make_candidate(0.8)]
+    result = ranker.rank(candidates)
+    assert result is not candidates
+
+
+def test_rank_does_not_mutate_input() -> None:
+    original_order = [0.3, 0.9, 0.6]
+    candidates = [_make_candidate(s) for s in original_order]
+    ranker.rank(candidates)
+    assert [c.score for c in candidates] == original_order
+
+
+def test_rank_empty_list() -> None:
+    assert ranker.rank([]) == []
+
+
+def test_rank_single_candidate() -> None:
+    c = _make_candidate(0.75)
+    assert ranker.rank([c]) == [c]
+
+
+def test_to_tsv_creates_file_with_score_column(tmp_path: Path) -> None:
+    candidates = [_make_candidate(0.8)]
+    out = tmp_path / "out.tsv"
+    ranker.to_tsv(candidates, out)
+    header = out.read_text(encoding="utf-8").splitlines()[0]
+    assert "score" in header.split("\t")
+
+
+def test_to_tsv_rows_match_candidates(tmp_path: Path) -> None:
+    candidates = [_make_candidate(0.8), _make_candidate(0.4)]
+    out = tmp_path / "out.tsv"
+    ranker.to_tsv(candidates, out)
+    lines = out.read_text(encoding="utf-8").strip().splitlines()
+    # header + one row per candidate
+    assert len(lines) == 1 + len(candidates)
+
+
+def test_to_tsv_score_value_in_row(tmp_path: Path) -> None:
+    c = _make_candidate(0.75)
+    out = tmp_path / "out.tsv"
+    ranker.to_tsv([c], out)
+    row = out.read_text(encoding="utf-8").splitlines()[1]
+    cols = row.split("\t")
+    header_cols = ranker.TSV_HEADER.split("\t")
+    score_idx = header_cols.index("score")
+    assert float(cols[score_idx]) == 0.75
+
+
+def test_to_tsv_empty_list(tmp_path: Path) -> None:
+    out = tmp_path / "out.tsv"
+    ranker.to_tsv([], out)
+    lines = out.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1  # header only
+
+
+def test_to_tsv_none_binding(tmp_path: Path) -> None:
+    """Candidates without a binding prediction produce empty binding columns."""
+    orf = ORF(frame=2, pos=10, length=30, dna="ATG" * 10)
+    effect = FrameEffect(
+        orf=orf, old_class="Silent", new_class="Stop_Gained", ref_aa="Q", alt_aa="*"
+    )
+    c = ScoredCandidate(
+        effect=effect,
+        binding=None,
+        domain_hits=[],
+        evidence=None,
+        score=0.0,
+    )
+    out = tmp_path / "out.tsv"
+    ranker.to_tsv([c], out)
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    # Should not raise; empty binding fields are fine
+    row = lines[1].split("\t")
+    header_cols = ranker.TSV_HEADER.split("\t")
+    assert row[header_cols.index("peptide_seq")] == ""
+    assert row[header_cols.index("allele")] == ""

--- a/tests/ranking/test_scorer.py
+++ b/tests/ranking/test_scorer.py
@@ -1,0 +1,133 @@
+"""Unit tests for ranking.scorer."""
+
+from ghostframe.models import (
+    ORF,
+    BindingPrediction,
+    DomainHit,
+    EvidenceLookupResult,
+    FrameEffect,
+    Peptide,
+)
+from ghostframe.ranking import scorer
+
+# --- Helpers ---
+
+
+def _make_orf() -> ORF:
+    return ORF(frame=1, pos=1, length=30, dna="ATG" * 10)
+
+
+def _make_effect() -> FrameEffect:
+    return FrameEffect(
+        orf=_make_orf(), old_class="Silent", new_class="Missense", ref_aa="A", alt_aa="V"
+    )
+
+
+def _make_binding(rank: float, affinity: float = 100.0) -> BindingPrediction:
+    return BindingPrediction(
+        peptide=Peptide(sequence="GILGFVFTL", start=0, k=9),
+        allele="HLA-A*02:01",
+        affinity=affinity,
+        rank=rank,
+    )
+
+
+def _make_domain_hit() -> DomainHit:
+    return DomainHit(accession="PF00071", name="Ras", start=5, end=39, score=42.0)
+
+
+def _make_evidence(tier: int) -> EvidenceLookupResult:
+    return EvidenceLookupResult(tier=tier)
+
+
+# --- Tests ---
+
+
+def test_score_perfect_candidate() -> None:
+    """rank=0, tier=3, domain hit → max score 1.0."""
+    s = scorer.score(
+        effect=_make_effect(),
+        binding=_make_binding(rank=0.0),
+        domain_hits=[_make_domain_hit()],
+        evidence=_make_evidence(tier=3),
+    )
+    assert s == 1.0
+
+
+def test_score_worst_candidate() -> None:
+    """rank=100, tier=1, no domains → min score 0.0."""
+    s = scorer.score(
+        effect=_make_effect(),
+        binding=_make_binding(rank=100.0),
+        domain_hits=[],
+        evidence=_make_evidence(tier=1),
+    )
+    assert s == 0.0
+
+
+def test_score_none_binding() -> None:
+    """binding=None → MHC term is 0; score is still a valid float."""
+    s = scorer.score(
+        effect=_make_effect(),
+        binding=None,
+        domain_hits=[],
+        evidence=_make_evidence(tier=1),
+    )
+    assert s == 0.0
+
+
+def test_score_none_evidence() -> None:
+    """evidence=None → treated as tier 1; MHC and domain terms still apply."""
+    s = scorer.score(
+        effect=_make_effect(),
+        binding=_make_binding(rank=0.0),
+        domain_hits=[_make_domain_hit()],
+        evidence=None,
+    )
+    # 0.5 * 1.0 + 0.3 * 0.0 + 0.2 = 0.7
+    assert abs(s - 0.7) < 1e-9
+
+
+def test_score_tier2_no_domain() -> None:
+    """tier=2 evidence, no domain, rank=0 → 0.5 + 0.15 + 0.0 = 0.65."""
+    s = scorer.score(
+        effect=_make_effect(),
+        binding=_make_binding(rank=0.0),
+        domain_hits=[],
+        evidence=_make_evidence(tier=2),
+    )
+    assert abs(s - 0.65) < 1e-9
+
+
+def test_acceptance_criteria_comparison() -> None:
+    """Acceptance criteria: IC50<500 + tier3 + domain > IC50>2000 + tier1 + no domain."""
+    # MHCflurry rank ~1-5 for IC50 < 500 nM strong binder; use rank=2 as representative
+    strong = scorer.score(
+        effect=_make_effect(),
+        binding=_make_binding(rank=2.0, affinity=300.0),
+        domain_hits=[_make_domain_hit()],
+        evidence=_make_evidence(tier=3),
+    )
+    # Weak binder: IC50 > 2000 nM corresponds to high rank; use rank=80
+    weak = scorer.score(
+        effect=_make_effect(),
+        binding=_make_binding(rank=80.0, affinity=2500.0),
+        domain_hits=[],
+        evidence=_make_evidence(tier=1),
+    )
+    assert strong > weak
+
+
+def test_score_range_all_tiers_and_ranks() -> None:
+    """All combinations of tier/rank/domain produce scores in [0, 1]."""
+    for tier in (1, 2, 3):
+        for rank in (0.0, 50.0, 100.0):
+            for has_domain in (True, False):
+                domain_hits = [_make_domain_hit()] if has_domain else []
+                s = scorer.score(
+                    effect=_make_effect(),
+                    binding=_make_binding(rank=rank),
+                    domain_hits=domain_hits,
+                    evidence=_make_evidence(tier=tier),
+                )
+                assert 0.0 <= s <= 1.0, f"Score {s} out of range for tier={tier} rank={rank}"


### PR DESCRIPTION
## Summary

- Adds `ranking/scorer.py` — `score()` returns a float in [0, 1] using a weighted formula: MHC percentile rank (0.5), evidence tier (0.3), domain presence (0.2)
- Adds `ranking/ranker.py` — `rank()` sorts candidates descending; `to_tsv()` exports to TSV with all 12 columns including `score`
- Adds `ScoredCandidate` dataclass to `models.py`; `DeepLaneResult` gains `ranked_candidates: list[ScoredCandidate]`
- Implements `reports/export.py` `to_tsv()` (delegates to `ranker.to_tsv`)
- 17 unit tests — all fast (no external API calls), all passing

## Acceptance criteria met

- [x] `scorer.score()` returns float in [0, 1]
- [x] IC50 < 500 nM + Tier 3 + domain hit scores higher than IC50 > 2000 nM + Tier 1 + no domain
- [x] `ranker.rank()` returns candidates sorted descending by score
- [x] `DeepLaneResult` contains `ranked_candidates: list[ScoredCandidate]`
- [x] `to_tsv()` includes `score` column

## Test plan

- `uv run pytest tests/ranking/ -v` — 17 tests pass
- `uv run pyright` — 0 errors
- `uv run ruff check .` — all checks pass