### PR TITLE
Make API URL and demo FASTA path configurable for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A multi-frame variant impact scanner for cancer bioinformatics. GhostFrame re-ex
 
 A "Silent" mutation in standard cancer annotations means the canonical protein sequence is unchanged. But in regions where multiple ORFs overlap, the same nucleotide change may be missense or stop-gained in an alternative reading frame. GhostFrame scans all 6 frames, finds these hidden effects, and prioritizes the resulting mutant peptides as noncanonical neoantigen candidates.
 
-**Output:** Interactive dashboard with Sankey reclassification flow, variant table, 3D frame explorer, and MHC binding scores. Also exports JSON/TSV for downstream use.
+**Output:** Interactive dashboard with Sankey reclassification flow, variant table, 3D frame explorer, and MHC binding scores (see [frontend/README.md](frontend/README.md)). Also exports JSON/TSV for downstream use.
 
 > **Research/educational use only. Not for clinical decision-making.**
 
@@ -21,7 +21,15 @@ git clone <repo-url>
 cd ghostframe
 uv sync
 
-# Run the ORF finder on the HPV16 demo
+# Start the API server
+uv run --package ghostframe-api uvicorn ghostframe_api.app:app --reload
+
+# Start the Next.js frontend (in a separate terminal)
+cd frontend
+npm install
+npm run dev   # http://localhost:3000
+
+# Run the ORF finder CLI on the HPV16 demo
 uv run --package ghostframe orfs data/demo/hpv16_k02718.fasta --min-len 50
 
 # Fetch a sequence region from a local FASTA (seqfetch)
@@ -79,9 +87,6 @@ print(f'Top score: {result.ranked_candidates[0].score:.3f}')
 
 # Run tests
 uv run pytest
-
-# Start the API server
-uv run --package ghostframe-api uvicorn ghostframe_api.app:app --reload
 ```
 
 ## Project layout
@@ -107,7 +112,7 @@ ghostframe/
   tests/                  # Test suite (mirrors source structure)
   data/demo/              # Sample data and expected outputs
   docs/                   # Architecture documentation
-  frontend/               # Next.js frontend (placeholder)
+  frontend/               # Next.js frontend — see frontend/README.md
 ```
 
 ## Pipeline architecture

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState, Suspense, lazy } from 'react';
+import { useState, Suspense } from 'react';
+import dynamic from 'next/dynamic';
+import config from '@/lib/config';
 import type { FrameEffect, DemoSummary } from '@/lib/types';
 import { DEMO_VARIANTS, DEMO_SUMMARY, DEMO_SANKEY, DEMO_SEQUENCE } from '@/lib/demo-data';
 
@@ -13,9 +15,9 @@ import DetailRow from '@/components/dashboard/DetailRow';
 import GenomeBrowser from '@/components/dashboard/GenomeBrowser';
 import AnalysisPanel from '@/components/dashboard/AnalysisPanel';
 
-// Heavy 3D components: lazy-loaded to keep initial bundle small
-const DnaBackground = lazy(() => import('@/components/background/DnaBackground'));
-const HelixExplorer = lazy(() => import('@/components/dashboard/HelixExplorer'));
+// Heavy 3D components: SSR disabled — Three.js requires browser WebGL APIs
+const DnaBackground = dynamic(() => import('@/components/background/DnaBackground'), { ssr: false });
+const HelixExplorer = dynamic(() => import('@/components/dashboard/HelixExplorer'), { ssr: false });
 
 const EMPTY_SUMMARY: DemoSummary = {
   total_silent: 0,
@@ -76,7 +78,7 @@ export default function DashboardPage() {
     setApiError(null);
 
     try {
-      const res = await fetch('http://localhost:8000/api/analyze', {
+      const res = await fetch(`${config.apiUrl}/api/analyze`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -1,0 +1,7 @@
+/** Application configuration loaded from environment variables. */
+const config = {
+  apiUrl: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000',
+  allowedDevOrigins: process.env.NEXT_PUBLIC_ALLOWED_DEV_ORIGINS?.split(',') ?? ['127.0.0.1'],
+};
+
+export default config;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,11 +1,13 @@
 import type { NextConfig } from "next";
+import config from './lib/config';
 
 const nextConfig: NextConfig = {
   // igv.esm.js accesses `document` at module load time, which causes Turbopack
   // to fail during server-side module evaluation. Marking it as a server
   // external package prevents bundling it for SSR entirely; the dynamic
   // import('igv') in useEffect runs only in the browser where DOM is available.
-  serverExternalPackages: ['igv'],
+  serverExternalPackages: ['igv', 'three'],
+  allowedDevOrigins: config.allowedDevOrigins,
 };
 
 export default nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "frontend",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/packages/ghostframe-api/src/ghostframe_api/config.py
+++ b/packages/ghostframe-api/src/ghostframe_api/config.py
@@ -1,6 +1,11 @@
 """Application settings via pydantic-settings."""
 
+from pathlib import Path
+
 from pydantic_settings import BaseSettings
+
+# Repo root when running from source; overridden by GHOSTFRAME_DEMO_FASTA in deployment
+_DEFAULT_DEMO_FASTA = Path(__file__).parents[4] / "data" / "demo" / "hpv16_k02718.fasta"
 
 
 class Settings(BaseSettings):
@@ -8,5 +13,6 @@ class Settings(BaseSettings):
 
     app_name: str = "GhostFrame"
     debug: bool = False
+    demo_fasta: Path = _DEFAULT_DEMO_FASTA
 
     model_config = {"env_prefix": "GHOSTFRAME_"}

--- a/packages/ghostframe-api/src/ghostframe_api/routes/analysis.py
+++ b/packages/ghostframe-api/src/ghostframe_api/routes/analysis.py
@@ -1,11 +1,11 @@
 """Analysis endpoints — submit jobs and retrieve results."""
 
 import uuid
-from pathlib import Path
 
 from fastapi import APIRouter
 
 from ghostframe.orfs import find_orfs, parse_file
+from ghostframe_api.config import Settings
 from ghostframe_api.schemas import (
     AnalysisRequest,
     AnalysisResponse,
@@ -13,8 +13,7 @@ from ghostframe_api.schemas import (
 )
 
 router = APIRouter()
-
-_DEMO_FASTA = Path(__file__).parents[6] / "data" / "demo" / "hpv16_k02718.fasta"
+_settings = Settings()
 
 
 @router.post("/analyze", response_model=AnalysisResponse)
@@ -35,7 +34,7 @@ async def start_analysis(request: AnalysisRequest) -> AnalysisResponse:
                 seq_lines = lines
             sequence = "".join(line.strip().upper() for line in seq_lines if line.strip())
         else:
-            records = parse_file(_DEMO_FASTA)
+            records = parse_file(_settings.demo_fasta)
             sequence = records[0].sequence
             label = records[0].id
         steps.append(


### PR DESCRIPTION
## Summary

- Fix 30-minute frontend compile hang by switching `React.lazy()` to `next/dynamic` with `ssr: false` for Three.js components (WebGL has no server-side runtime)
- Centralize all frontend env config in `lib/config.ts`; add `.env.example`
- `NEXT_PUBLIC_API_URL` replaces hardcoded `http://localhost:8000`
- `NEXT_PUBLIC_ALLOWED_DEV_ORIGINS` replaces hardcoded `['127.0.0.1']` in `next.config.ts`
- Move demo FASTA path into `Settings` as `GHOSTFRAME_DEMO_FASTA` (overridable via env var)
- Fix off-by-one `parents[6]` → `parents[4]` after path constant moved from `routes/analysis.py` into `config.py`

## Test plan

- [ ] `npm run dev` in `frontend/` starts in <5 seconds (no compile hang)
- [ ] Dashboard loads at http://localhost:3000
- [ ] `curl http://localhost:8000/health` returns `{"status":"ok"}`
- [ ] `curl -X POST http://localhost:8000/api/analyze` with accession payload returns ORF results
- [ ] Setting `NEXT_PUBLIC_API_URL` to a different host routes requests there
- [ ] Setting `GHOSTFRAME_DEMO_FASTA` to an alternate path loads that file