### PR TITLE
fix: make mhcflurry an optional [mhc] extra

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       # Forward deploy key into SSH agent so PSR can push past branch protection
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 

--- a/packages/ghostframe-api/pyproject.toml
+++ b/packages/ghostframe-api/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
-    "ghostframe",
+    "ghostframe[mhc]",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "pydantic>=2.0",

--- a/packages/ghostframe/pyproject.toml
+++ b/packages/ghostframe/pyproject.toml
@@ -11,10 +11,12 @@ requires-python = ">=3.13"
 dependencies = [
     "click>=8.1",
     "httpx>=0.27",
-    "mhcflurry>=2.2.0rc1",
     "pandas>=2.0",
     "pyfaidx>=0.8",
 ]
+
+[project.optional-dependencies]
+mhc = ["mhcflurry>=2.2.0rc1"]
 
 [project.scripts]
 orfs = "ghostframe.cli.orfs:main"

--- a/packages/ghostframe/src/ghostframe/mhc/mhcflurry.py
+++ b/packages/ghostframe/src/ghostframe/mhc/mhcflurry.py
@@ -5,9 +5,14 @@ Wraps the MHCflurry open-source MHC-I binding predictor.
 Pipeline position: peptides → [mhc.mhcflurry] → reports
 """
 
-import numpy as np
-import torch
-from mhcflurry import Class1PresentationPredictor  # type: ignore[import-untyped]
+try:
+    import numpy as np
+    import torch
+    from mhcflurry import Class1PresentationPredictor  # type: ignore[import-untyped]
+except ImportError as _e:
+    raise ImportError(
+        "MHC prediction requires the 'mhc' extra: pip install 'ghostframe[mhc]'"
+    ) from _e
 
 from ghostframe.mhc.base import MHCPredictor
 from ghostframe.models import BindingPrediction, Peptide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = []
 
 [dependency-groups]
 dev = [
-    "ghostframe",
+    "ghostframe[mhc]",
     "ghostframe-api",
     "pytest>=8.0",
     "pytest-cov>=6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -321,24 +321,29 @@ wheels = [
 
 [[package]]
 name = "ghostframe"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "packages/ghostframe" }
 dependencies = [
     { name = "click" },
     { name = "httpx" },
-    { name = "mhcflurry" },
     { name = "pandas" },
     { name = "pyfaidx" },
+]
+
+[package.optional-dependencies]
+mhc = [
+    { name = "mhcflurry" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "mhcflurry", specifier = ">=2.2.0rc1" },
+    { name = "mhcflurry", marker = "extra == 'mhc'", specifier = ">=2.2.0rc1" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pyfaidx", specifier = ">=0.8" },
 ]
+provides-extras = ["mhc"]
 
 [[package]]
 name = "ghostframe-api"
@@ -346,7 +351,7 @@ version = "0.1.0"
 source = { editable = "packages/ghostframe-api" }
 dependencies = [
     { name = "fastapi" },
-    { name = "ghostframe" },
+    { name = "ghostframe", extra = ["mhc"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "uvicorn", extra = ["standard"] },
@@ -355,7 +360,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
-    { name = "ghostframe", editable = "packages/ghostframe" },
+    { name = "ghostframe", extras = ["mhc"], editable = "packages/ghostframe" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
@@ -368,7 +373,7 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
-    { name = "ghostframe" },
+    { name = "ghostframe", extra = ["mhc"] },
     { name = "ghostframe-api" },
     { name = "pandas-stubs" },
     { name = "pre-commit" },
@@ -383,7 +388,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "ghostframe", editable = "packages/ghostframe" },
+    { name = "ghostframe", extras = ["mhc"], editable = "packages/ghostframe" },
     { name = "ghostframe-api", editable = "packages/ghostframe-api" },
     { name = "pandas-stubs", specifier = ">=2.0" },
     { name = "pre-commit", specifier = ">=4.0" },


### PR DESCRIPTION
## Summary
- `pip install ghostframe` no longer pulls in torch/mhcflurry — works in Pyodide environments like python-playground.com
- `pip install 'ghostframe[mhc]'` installs the full MHC binding prediction stack
- `ghostframe-api` and the dev workspace both updated to `ghostframe[mhc]` so deployments and tests are unaffected
- Importing `ghostframe.mhc.mhcflurry` without the extra raises a clear `ImportError` pointing to the fix

## Test plan
- [ ] `uv sync` resolves cleanly (mhcflurry still installed via workspace dev deps)
- [ ] Existing MHC tests still pass (`uv run pytest tests/mhc/`)
- [ ] Merging triggers the release workflow → PSR cuts 1.0.1 → PyPI publish
- [ ] `pip install ghostframe` in python-playground.com installs without error