### PR TITLE
ci: regenerate uv.lock in PSR release commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "RUF"]
 [tool.semantic_release]
 version_toml = ["packages/ghostframe/pyproject.toml:project.version"]
 tag_format = "v{version}"
-build_command = "uv build --package ghostframe"
+build_command = "uv lock && uv build --package ghostframe"
 commit_message = "chore(release): v{version} [skip ci]"
 no_git_verify = true
 


### PR DESCRIPTION
## Summary
- Adds `uv lock` before `uv build` in `build_command` so PSR includes an updated `uv.lock` in its `chore(release)` commit
- Fixes stale version entry in `uv.lock` after each release (was showing previous version)

## Test plan
- [ ] Merge and trigger a release — `uv.lock` should show the new version in the release commit